### PR TITLE
chore: promote origins-cms to version 0.0.6

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-2f7p9-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-2f7p9-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-kstxg
+  name: jx-verify-gc-jobs-2f7p9
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-iekgc-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-iekgc-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-1wdzr
+  name: jx-verify-gc-jobs-iekgc
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-0gys7
+    app: jx-verify-gc-jobs-9jemo
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-ingress.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: origins-cms/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'origins-cms'
+  name: origins-cms
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: origins-cms
+                port:
+                  number: 3005
+      host: origins-cms-jx-production.35.239.154.70.nip.io

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-deploy.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-deploy.yaml
@@ -1,0 +1,70 @@
+# Source: origins-cms/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: origins-cms-origins-cms
+  labels:
+    draft: draft-app
+    chart: "origins-cms-0.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'origins-cms'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: origins-cms-origins-cms
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: origins-cms-origins-cms
+    spec:
+      serviceAccountName: origins-cms-origins-cms
+      containers:
+        - name: origins-cms
+          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.6"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: SESSION_SECRET
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: DATABASE_URL
+            - name: VERSION
+              value: 0.0.6
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 3005
+          livenessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3005
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3005
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-sa.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-sa.yaml
@@ -1,0 +1,10 @@
+# Source: origins-cms/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: origins-cms-origins-cms
+  annotations:
+    meta.helm.sh/release-name: 'origins-cms'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-svc.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-svc.yaml
@@ -1,0 +1,20 @@
+# Source: origins-cms/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: origins-cms
+  labels:
+    chart: "origins-cms-0.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'origins-cms'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3005
+      targetPort: 3005
+      protocol: TCP
+      name: http
+  selector:
+    app: origins-cms-origins-cms

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-bqtko-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-bqtko-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-xrcjw
+  name: jx-verify-gc-jobs-bqtko
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-3u6cg
+    app: jx-verify-gc-jobs-mesqx
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-igpyq-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-igpyq-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-atln5
+  name: jx-verify-gc-jobs-igpyq
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
+	      <td>0.0.6</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -16,6 +16,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.6
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-03-12T13:48:13Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-03-12T13:48:13Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
+    name: origins-cms
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.239.154.70.nip.io
+    resourcePath: config-root/namespaces/jx-production/origins-cms
+    version: 0.0.6
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.35.239.154.70.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/origins-cms
+  version: 0.0.6
+  name: origins-cms
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.6
   name: origins-cms
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote origins-cms to version 0.0.6

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
