### PR TITLE
chore: promote origins-cms to version 0.0.9

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-afegm-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-afegm-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-umux0
+  name: jx-verify-gc-jobs-afegm
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-wqdpb
+    app: jx-verify-gc-jobs-xebes
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-jd2sq-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-jd2sq-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-9ebu3
+  name: jx-verify-gc-jobs-jd2sq
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-aq4wl-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-aq4wl-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-orhft
+  name: jx-verify-gc-jobs-aq4wl
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-l70yt
+    app: jx-verify-gc-jobs-3uav4
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-idqwl-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-idqwl-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-bpjmv
+  name: jx-verify-gc-jobs-idqwl
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-deploy.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: origins-cms-origins-cms
   labels:
     draft: draft-app
-    chart: "origins-cms-0.0.8"
+    chart: "origins-cms-0.0.9"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'
@@ -25,21 +25,21 @@ spec:
       serviceAccountName: origins-cms-origins-cms
       containers:
         - name: origins-cms
-          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.8"
+          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.9"
           imagePullPolicy: IfNotPresent
           env:
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: origins-cms-secrets
+                  name: origins-cms-app-secrets
                   key: SESSION_SECRET
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: origins-cms-secrets
+                  name: origins-cms-app-secrets
                   key: DATABASE_URL
             - name: VERSION
-              value: 0.0.8
+              value: 0.0.9
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-svc.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: origins-cms
   labels:
-    chart: "origins-cms-0.0.8"
+    chart: "origins-cms-0.0.9"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
-	      <td>0.0.8</td>
+	      <td>0.0.9</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -33,17 +33,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
   - apiVersion: v1
-    appVersion: 0.0.8
+    appVersion: 0.0.9
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-03-13T13:07:35Z"
+    firstDeployed: "2022-03-13T13:30:05Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-03-13T13:07:35Z"
+    lastDeployed: "2022-03-13T13:30:05Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
     name: origins-cms
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.239.154.70.nip.io
     resourcePath: config-root/namespaces/jx-staging/origins-cms
-    version: 0.0.8
+    version: 0.0.9
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/origins-cms
-  version: 0.0.8
+  version: 0.0.9
   name: origins-cms
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote origins-cms to version 0.0.9

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
